### PR TITLE
Remove atom selection from tutorial scripts

### DIFF
--- a/tutorials/tutorial1-phase-transition/mdanse_inputs/script3_rmsd.py
+++ b/tutorials/tutorial1-phase-transition/mdanse_inputs/script3_rmsd.py
@@ -11,8 +11,6 @@ from MDANSE.Framework.Jobs.IJob import IJob
 ########################################################
 
 parameters = {
-    'atom_selection': '{"all": true}',                  # atom_selection
-    'atom_transmutation': '{}',                         # atom_transmutation
     'frames': [0, 1000, 1],                             # frames
     'grouping_level': 'atom',                           # grouping_level
     'output_files': ('../mdanse_outputs/root_mean_square_displacement', ['MDAFormat'], "INFO"),  # output_files

--- a/tutorials/tutorial1-phase-transition/mdanse_inputs/script4_pdf.py
+++ b/tutorials/tutorial1-phase-transition/mdanse_inputs/script4_pdf.py
@@ -11,8 +11,6 @@ from MDANSE.Framework.Jobs.IJob import IJob
 ########################################################
 
 parameters = {
-    'atom_selection': '{"all": true}',                  # atom_selection
-    'atom_transmutation': '{}',                         # atom_transmutation
     'frames': [0, 500, 1],                              # frames
     'output_files': ('../mdanse_outputs/pair_distribution_function_solid', ['MDAFormat'], "INFO"),  # output_files
     'r_values': [0.0, 1.32, 0.01],                      # r values (nm)

--- a/tutorials/tutorial2-van-hove-function/mdanse_inputs/script2_vhfd.py
+++ b/tutorials/tutorial2-van-hove-function/mdanse_inputs/script2_vhfd.py
@@ -11,7 +11,6 @@ from MDANSE.Framework.Jobs.IJob import IJob
 ########################################################
 
 parameters = {
-    'atom_selection': '{"all": true}',                  # atom_selection
     'frames': [0, 1001, 1, 501],                        # frames
     'output_files': ('../mdanse_outputs/vanhovefunctiondistinct', ['MDAFormat'], 'INFO'),  # output_files
     'r_values': [0.0, 1.14, 0.01],                      # r values (nm)

--- a/tutorials/tutorial2-van-hove-function/mdanse_inputs/script3_vhfs.py
+++ b/tutorials/tutorial2-van-hove-function/mdanse_inputs/script3_vhfs.py
@@ -11,7 +11,6 @@ from MDANSE.Framework.Jobs.IJob import IJob
 ########################################################
 
 parameters = {
-    'atom_selection': '{"all": true}',                  # atom_selection
     'frames': [0, 1001, 1, 31],                         # frames
     'output_files': ('../mdanse_outputs/vanhovefunctionself', ['MDAFormat'], 'INFO'),  # output_files
     'r_values': [0.0, 1.14, 0.01],                      # r values (nm)

--- a/tutorials/tutorial3-quasielastic-neutron-scattering/mdanse_inputs/script2_disf.py
+++ b/tutorials/tutorial3-quasielastic-neutron-scattering/mdanse_inputs/script2_disf.py
@@ -11,8 +11,6 @@ from MDANSE.Framework.Jobs.IJob import IJob
 ########################################################
 
 parameters = {
-    'atom_selection': '{"all": true}',                  # atom_selection
-    'atom_transmutation': '{}',                         # atom_transmutation
     'frames': [0, 1001, 1, 501],                        # frames
     'grouping_level': 'atom',                           # grouping_level
     'instrument_resolution': ('ideal', {}),             # instrument_resolution

--- a/tutorials/tutorial3-quasielastic-neutron-scattering/mdanse_inputs/script3_gdisf.py
+++ b/tutorials/tutorial3-quasielastic-neutron-scattering/mdanse_inputs/script3_gdisf.py
@@ -11,8 +11,6 @@ from MDANSE.Framework.Jobs.IJob import IJob
 ########################################################
 
 parameters = {
-    'atom_selection': '{"all": true}',                  # atom_selection
-    'atom_transmutation': '{}',                         # atom_transmutation
     'frames': [0, 1001, 1, 501],                        # frames
     'grouping_level': 'atom',                           # grouping_level
     'instrument_resolution': ('ideal', {}),             # instrument_resolution


### PR DESCRIPTION
Remove explicit "atom_selection" from tutorial scripts. Defaults will be used.

closes #15 
